### PR TITLE
[unitaryhack] Making flaky randomized perturbation tests deterministic by setting a random seed.

### DIFF
--- a/tests/orquestra/vqa/opt/fourier_test.py
+++ b/tests/orquestra/vqa/opt/fourier_test.py
@@ -89,6 +89,15 @@ def inner_optimizer():
     return inner_optimizer
 
 
+@pytest.fixture(scope="class")
+def deterministic_randomness():
+    rng_state = np.random.get_state()
+    np.random.seed(358)
+    yield
+    np.random.set_state(rng_state)
+
+
+@pytest.mark.usefixtures("deterministic_randomness")
 class TestFourier:
     @pytest.mark.parametrize("contract", NESTED_OPTIMIZER_CONTRACTS)
     def test_if_satisfies_contracts(
@@ -271,6 +280,7 @@ class TestFourier:
         optimizer.minimize(cost_function_without_gradients_factory, np.ones(2))
 
 
+@pytest.mark.usefixtures("deterministic_randomness")
 class TestPerturbations:
     def test_finds_best_params_from_list(self, ansatz, inner_optimizer):
         params_list = [np.array([i]) for i in [-5, -4, -3, 2, 3, 4, 7, 9]]


### PR DESCRIPTION
## Description

Fixes [orquestra-core/#11](https://github.com/zapatacomputing/orquestra-core/issues/11) by introducing a `pytest` fixture that allows tests dealing with randomness to be made deterministic. In the setup phase, the fixture stores the current state of the random number generator and then sets the random seed to a pre-determined value. In the teardown phase, the fixture resets the random number generator state to what it was prior. This ensures that the random seed used by the fixture only applies to those tests we've annotated and no others that may occur later in the build.

This is useful as removing these flaky tests will reduce occurences of builds failing for reasons unrelated to code changes.