### PR TITLE
Fix typing_extensions.

### DIFF
--- a/src/orquestra/vqa/estimation/cvar.py
+++ b/src/orquestra/vqa/estimation/cvar.py
@@ -1,7 +1,7 @@
 ################################################################################
 # © Copyright 2021-2022 Zapata Computing Inc.
 ################################################################################
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union, overload
 
 import numpy as np
 from orquestra.quantum.api.backend import QuantumBackend, QuantumSimulator
@@ -11,7 +11,6 @@ from orquestra.quantum.measurements import ExpectationValues, check_parity_of_ve
 from orquestra.quantum.openfermion import IsingOperator
 from orquestra.quantum.utils import dec2bin
 from orquestra.quantum.wavefunction import Wavefunction
-from typing_extensions import overload
 
 PROBABILITY_CUTOFF = 1e-8
 


### PR DESCRIPTION
## Description

After moving from Python 3.7 to 3.8 we can stop using `typing_extensions` and start using `typing` in some places. This PR makes appropriate changes.

## Please verify that you have completed the following steps

- [X] I have self-reviewed my code.
