### PR TITLE
chore!: include coefficients in expectation values

### DIFF
--- a/src/orquestra/vqa/grouping/_grouping.py
+++ b/src/orquestra/vqa/grouping/_grouping.py
@@ -153,15 +153,17 @@ def compute_group_variances(
     """Computes the variances of each frame in a grouped operator.
 
     If expectation values are provided, use variances from there,
-    otherwise assume variances are 1 (upper bound). Correlation information
+    otherwise assume the upper bound for variances. Correlation information
     is ignored in the current implementation, covariances are assumed to be 0.
 
     Args:
-        groups:  A list of pauli operators that defines a (grouped) operator
+        groups:  A list of Pauli terms that defines a (grouped) operator
         expecval: An ExpectationValues object containing the expectation
-            values of the operators.
+            values of each Pauli term. The term coefficients should be
+            included in the expectation values, e.g. the expectation value of
+            2*Z0 should be between -2 and 2.
     Returns:
-        frame_variances: A Numpy array of the computed variances for each frame
+        frame_variances: Computed variances for each frame.
     """
 
     if expecval is None:

--- a/src/orquestra/vqa/grouping/_grouping.py
+++ b/src/orquestra/vqa/grouping/_grouping.py
@@ -174,19 +174,18 @@ def compute_group_variances(
                 "Number of expectation values should be the same as number of terms."
             )
         real_expecval = expectation_values_to_real(expecval)
-        if not np.logical_and(
-            real_expecval.values >= -1, real_expecval.values <= 1
-        ).all():
-            raise ValueError("Expectation values should have values between -1 and 1.")
-
-        pauli_variances = 1.0 - real_expecval.values**2
         frame_variances = []
         for i, group in enumerate(groups):
             coeffs = np.array([term.coefficient for term in group.terms])
             offset = 0 if i == 0 else np.sum(group_sizes[:i])
-            pauli_variances_for_group = pauli_variances[
+            real_expecval_for_group = real_expecval.values[
                 offset : offset + group_sizes[i]
             ]
-            frame_variances.append(np.sum(coeffs**2 * pauli_variances_for_group))
+            if (np.abs(real_expecval_for_group) > np.abs(coeffs)).any():
+                raise ValueError(
+                    "Absolute value of expectation value exceeds absolute value of Pauli term coefficient."
+                )
+
+            frame_variances.append(np.sum(coeffs**2 - real_expecval_for_group**2))
 
     return np.array(frame_variances)

--- a/src/orquestra/vqa/grouping/_grouping.py
+++ b/src/orquestra/vqa/grouping/_grouping.py
@@ -185,7 +185,8 @@ def compute_group_variances(
             ]
             if (np.abs(real_expecval_for_group) > np.abs(coeffs)).any():
                 raise ValueError(
-                    "Absolute value of expectation value exceeds absolute value of Pauli term coefficient."
+                    "Absolute value of expectation value exceeds absolute value of"
+                    "Pauli term coefficient."
                 )
 
             frame_variances.append(np.sum(coeffs**2 - real_expecval_for_group**2))

--- a/src/orquestra/vqa/opt/recursive_qaoa.py
+++ b/src/orquestra/vqa/opt/recursive_qaoa.py
@@ -243,6 +243,8 @@ def _find_term_with_strongest_correlation(
     """
     largest_expval = 0.0
 
+    term_with_largest_expval = hamiltonian.terms[0]
+
     for term in hamiltonian.terms:
         # If term is a constant term, don't calculate expectation value.
         if not term.is_constant:

--- a/src/orquestra/vqa/shot_allocation/_shot_allocation.py
+++ b/src/orquestra/vqa/shot_allocation/_shot_allocation.py
@@ -99,7 +99,10 @@ def estimate_nmeas_for_frames(
             each element in the list is a group of co-measurable terms.
         expecval (Optional[ExpectationValues]): An ExpectationValues object containing
             the expectation values of all operators in frame_operators. If absent,
-            variances are assumed to be maximal, i.e. 1.
+            variances are assumed to be maximal (i.e. equal to the square of the
+            term's coefficient). Note that the term coefficients should be
+            included in the expectation values, e.g. the expectation value of
+            2*Z0 should be between -2 and 2.
             NOTE: YOU HAVE TO MAKE SURE THAT THE ORDER OF EXPECTATION VALUES MATCHES
             THE ORDER OF THE TERMS IN THE *GROUPED* TARGET QUBIT OPERATOR, OTHERWISE
             THIS FUNCTION WILL NOT RETURN THE CORRECT RESULT.

--- a/tests/orquestra/vqa/shot_allocation/shot_allocation_test.py
+++ b/tests/orquestra/vqa/shot_allocation/shot_allocation_test.py
@@ -96,7 +96,7 @@ class TestShotAllocation:
         [
             (400, None, [200, 100, 100]),
             (400, ExpectationValues(np.array([0, 0, 0])), [200, 100, 100]),
-            (400, ExpectationValues(np.array([1, 0.3, 0.3])), [0, 200, 200]),
+            (400, ExpectationValues(np.array([2, 0.3, 0.3])), [0, 200, 200]),
         ],
     )
     def test_allocate_shots_proportionally(


### PR DESCRIPTION
## Description

Updates shot allocation to follow the same convention as estimators regarding expectation values. Namely that the expectation values should include the coefficients of Pauli terms.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [x] I have updated documentation.
