### PR TITLE
fix: incorrectly formatted docstrings

### DIFF
--- a/src/orquestra/vqa/ansatz/singlet_uccsd.py
+++ b/src/orquestra/vqa/ansatz/singlet_uccsd.py
@@ -116,6 +116,7 @@ class SingletUCCSDAnsatz(Ansatz):
     ) -> Tuple[np.ndarray, FermionOperator]:
         """Screen single and double excitation operators based on a guess
             for the amplitudes
+
         Args:
             threshold (float): threshold to select excitations. Only those with
                 absolute amplitudes above the threshold are kept.
@@ -124,7 +125,7 @@ class SingletUCCSDAnsatz(Ansatz):
         Returns:
             amplitudes (np.array): screened amplitudes
             new_fermion_generator (openfermion.FermionOperator): screened
-                Fermion Operator
+            Fermion Operator
         """
 
         new_fermion_generator = FermionOperator()

--- a/src/orquestra/vqa/cost_function/cost_function.py
+++ b/src/orquestra/vqa/cost_function/cost_function.py
@@ -151,6 +151,9 @@ def create_cost_function(
         A callable CostFunction object.
 
     Example use case:
+
+    .. code:: python
+
         target_operator = ...
         ansatz = ...
 

--- a/src/orquestra/vqa/cost_function/qcbm_cost_function.py
+++ b/src/orquestra/vqa/cost_function/qcbm_cost_function.py
@@ -31,6 +31,7 @@ def create_QCBM_cost_function(
     gradient_function: GradientFactory = finite_differences_gradient,
 ) -> CostFunction:
     """Cost function used for evaluating QCBM.
+
     Args:
         ansatz: the ansatz used to construct the variational circuits
         runner: runner used for QCBM evaluation
@@ -74,8 +75,7 @@ def _create_QCBM_cost_function(
     def cost_function(
         parameters: np.ndarray, store_artifact: Optional[StoreArtifact] = None
     ) -> ValueEstimate:
-        """
-        Evaluates the value of the cost function for given parameters.
+        """Evaluates the value of the cost function for given parameters.
 
         Args:
             parameters: parameters for which the evaluation should occur.

--- a/src/orquestra/vqa/shot_allocation/_shot_allocation.py
+++ b/src/orquestra/vqa/shot_allocation/_shot_allocation.py
@@ -92,7 +92,7 @@ def estimate_nmeas_for_frames(
     :math:`prec(H_{i}) = sum{ab} |h_{a}^{i}||h_{b}^{i}| cov(O_{a}^{i}, O_{b}^{i})`
     where :math:`h_{a}^{i}` is the coefficient of the a-th operator, :math:`O_{a}^{i}`,
     in the i-th group. Covariances are assumed to be zero for a != b:
-    :math:`cov(O_{a}^{i}, O_{b}^{i}) = <O_{a}^{i} O_{b}^{i}> - <O_{a}^{i}> <O_{b}^{i}> = 0`
+    :math:`cov(O_{a}^{i},O_{b}^{i})=<O_{a}^{i}O_{b}^{i}>-<O_{a}^{i}><O_{b}^{i}>=0`
 
     Args:
         frame_operators: A list of pauli operators, where

--- a/src/orquestra/vqa/shot_allocation/_shot_allocation.py
+++ b/src/orquestra/vqa/shot_allocation/_shot_allocation.py
@@ -86,18 +86,18 @@ def estimate_nmeas_for_frames(
 
     We are assuming the exact expectation values are provided
     (i.e. infinite number of measurements or simulations without noise)
-    M ~ (sum_{i} prec(H_i)) ** 2.0 / (epsilon ** 2.0)
-    where prec(H_i) is the precision (square root of the variance)
+    :math:`M ~ (sum_{i} prec(H_i)) ** 2.0 / (epsilon ** 2.0)`
+    where :math:`prec(H_i)` is the precision (square root of the variance)
     for each group of co-measurable terms H_{i}. It is computed as
-    prec(H_{i}) = sum{ab} |h_{a}^{i}||h_{b}^{i}| cov(O_{a}^{i}, O_{b}^{i})
-    where h_{a}^{i} is the coefficient of the a-th operator, O_{a}^{i}, in the
-    i-th group. Covariances are assumed to be zero for a != b:
-    cov(O_{a}^{i}, O_{b}^{i}) = <O_{a}^{i} O_{b}^{i}> - <O_{a}^{i}> <O_{b}^{i}> = 0
+    :math:`prec(H_{i}) = sum{ab} |h_{a}^{i}||h_{b}^{i}| cov(O_{a}^{i}, O_{b}^{i})`
+    where :math:`h_{a}^{i}` is the coefficient of the a-th operator, :math:`O_{a}^{i}`,
+    in the i-th group. Covariances are assumed to be zero for a != b:
+    :math:`cov(O_{a}^{i}, O_{b}^{i}) = <O_{a}^{i} O_{b}^{i}> - <O_{a}^{i}> <O_{b}^{i}> = 0`
 
     Args:
-        frame_operators (List[PauliRepresentation]): A list of pauli operators, where
+        frame_operators: A list of pauli operators, where
             each element in the list is a group of co-measurable terms.
-        expecval (Optional[ExpectationValues]): An ExpectationValues object containing
+        expecval: An ExpectationValues object containing
             the expectation values of all operators in frame_operators. If absent,
             variances are assumed to be maximal (i.e. equal to the square of the
             term's coefficient). Note that the term coefficients should be


### PR DESCRIPTION
## Description

This fixes the docstrings formatting, thus reducing the number of errors/warnings occurring when building orquestra-core docs.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [x] I have updated documentation.
